### PR TITLE
Add Login API that return token

### DIFF
--- a/linku_backend/linku/settings.py
+++ b/linku_backend/linku/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'corsheaders',
     'rest_framework',
+    'rest_framework.authtoken',
     'meeting',
 ]
 
@@ -108,6 +109,10 @@ CORS_ORIGIN_WHITELIST = (
 # REST_FRAMEWORK
 REST_FRAMEWORK = {
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',  # Use application/json instead of multipart/form-data requests in tests.
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    )
 }
 
 # Internationalization

--- a/linku_backend/linku/urls.py
+++ b/linku_backend/linku/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 from django.conf.urls import url, include
 from django.conf.urls.static import static
 from django.conf import settings
+from django.contrib import admin
 from rest_framework import routers
+
 from meeting import views
+from rest_framework.authtoken.views import obtain_auth_token
 
 router = routers.DefaultRouter()
 router.register(r'meetings', views.MeetingViewSet)
@@ -25,8 +28,10 @@ router.register(r'users', views.UserViewSet)
 router.register(r'subimages', views.SubImageViewSet)
 
 urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
     url(r'^', include(router.urls)),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^login/', obtain_auth_token)
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/linku_backend/meeting/admin.py
+++ b/linku_backend/meeting/admin.py
@@ -1,3 +1,8 @@
 from django.contrib import admin
+from meeting.models import User
 
 # Register your models here.
+
+class UserAdmin(admin.ModelAdmin):
+    pass
+admin.site.register(User, UserAdmin)

--- a/linku_backend/meeting/models.py
+++ b/linku_backend/meeting/models.py
@@ -1,7 +1,10 @@
 from django.db import models
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, UserManager
 from django.conf import settings
 from django.core.validators import RegexValidator
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
 
 SAVED_MEETING_DEFAULT_IMAGE_NAME = 'meeting_default_image.jpg'
 
@@ -19,6 +22,12 @@ class User(AbstractUser):
     phone_number = models.CharField(max_length=11, validators=[phone_regex])
     authenticated_university_email = models.EmailField(unique=True, null=False, max_length=254)
     profile_image_path = models.ImageField(blank=True)
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)
 
 
 class Meeting(models.Model):

--- a/linku_backend/meeting/serializer.py
+++ b/linku_backend/meeting/serializer.py
@@ -20,6 +20,14 @@ class MeetingSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
+    def create(self, validated_data):
+        password = validated_data.pop('password', None)
+        instance = self.Meta.model(**validated_data)
+        if password is not None:
+            instance.set_password(password)
+        instance.save()
+        return instance
+
     class Meta:
         model = User
         fields = ('username', 'nickname', 'gender', 'password', 'phone_number', 'authenticated_university_email')

--- a/linku_backend/meeting/tests.py
+++ b/linku_backend/meeting/tests.py
@@ -248,3 +248,31 @@ def test_sign_up_phone_number_field_validation(client):
 
     assert response.status_code == 400
     assert 'Phone length has to be 11 & Only number' in response.data['phone_number']
+
+
+@pytest.mark.django_db
+def test_correct_login(client):
+    login_data = {
+        'username': 'test@test.com',
+        'password': 'test password',
+    }
+
+    response = client.post('/login/', login_data)
+
+    assert response.status_code == 400
+    assert 'Unable to log in with provided credentials.' in response.data['non_field_errors']
+
+    signup_data = {
+        'username': 'test@test.com',
+        'nickname': 'test nickname',
+        'gender': 'M',
+        'password': 'test password',
+        'phone_number': '01000000000',
+        'authenticated_university_email': 'test@authenticated.ac.kr'
+    }
+
+    client.post('/users/', signup_data)
+    response = client.post('/login/', login_data)
+
+    assert response.status_code == 200
+    assert 'token' in response.data.keys()

--- a/linku_backend/meeting/views.py
+++ b/linku_backend/meeting/views.py
@@ -1,7 +1,7 @@
 from rest_framework import viewsets
 
 from .serializer import MeetingSerializer, UserSerializer, SubImageSerializer
-from .models import Meeting, User
+from .models import Meeting, User, SubImage
 
 
 class MeetingViewSet(viewsets.ModelViewSet):
@@ -13,6 +13,7 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
+
 class SubImageViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
+    queryset = SubImage.objects.all()
     serializer_class = SubImageSerializer


### PR DESCRIPTION
- setup DRF TokenAuthentication
- override serializer `create` method for hashing user's password 
- test `/login/' API